### PR TITLE
bug fixed：使用 getAsync() 进行异步请求时，报错：Call to undefined method GuzzleHttp\Promise\Promise::swaggerFormats()

### DIFF
--- a/src/TencentAds/Kernel/SerializerHandler.php
+++ b/src/TencentAds/Kernel/SerializerHandler.php
@@ -7,6 +7,7 @@
 
 namespace TencentAds\Kernel;
 
+use GuzzleHttp\Promise\Promise;
 use TencentAds\ObjectSerializer;
 
 class SerializerHandler extends ObjectSerializer
@@ -34,7 +35,7 @@ class SerializerHandler extends ObjectSerializer
      */
     public static function sanitizeForSerializationToArray($data, $type = null, $format = null)
     {
-        if (is_scalar($data) || null === $data) {
+        if (is_scalar($data) || null === $data || $data instanceof Promise) {
             return $data;
         } elseif ($data instanceof \DateTime) {
             return ($format === 'date') ? $data->format('Y-m-d') : $data->format(\DateTime::ATOM);


### PR DESCRIPTION
bug fixed：使用 getAsync() 进行异步请求时，报错：Call to undefined method GuzzleHttp\Promise\Promise::swaggerFormats()

错误位置 FILE: D:\test\vendor\tencent-ad\marketing-api-php-sdk\src\TencentAds\Kernel\SerializerHandler.php 　LINE: 55